### PR TITLE
Update RouteGroup.view.ts

### DIFF
--- a/src/Router/RouteGroup.view.ts
+++ b/src/Router/RouteGroup.view.ts
@@ -113,7 +113,7 @@ class RouteGroup implements RouteGroupProps {
           this._dl_router_baseUrl
         )
         if (canGo === false) {
-          this.navigator.to(this.prevInfo.path)
+          this.prevInfo.path && this.navigator.to(this.prevInfo.path)
           return
         }
         if (typeof canGo === "string") {


### PR DESCRIPTION
The page enter a dead loop when 'this.prevInfo.path' is empty ''.  When the route is accessed directly, 'this.prevInfo.path' is ''